### PR TITLE
Display index page at root URL.

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,6 +84,15 @@ func main() {
 
 	log.Printf("Initialization succesful. Listening on :%s\n", *port)
 	http.HandleFunc("/metrics", metricsHandler)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+			<head><title>Sensor Exporter</title></head>
+			<body>
+			<h1>Sensor Exporter</h1>
+			<p><a href="/metrics">Metrics</a></p>
+			</body>
+			</html>`))
+	})
 	http.ListenAndServe(":"+*port, nil)
 
 }


### PR DESCRIPTION
This is nice for browsers, but also allows monitoring that the service
is up (by looking for a valid HTTP response), without needing to render
the full collection.